### PR TITLE
feat: add optional bank sync before reconciliation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,8 @@ TZ=America/New_York        # Timezone
 # Optional — Category configuration
 # FAFO_OTHER_CATEGORY=Everything Else   # Name of catch-all category in Other group
 
+# Optional — Bank sync
+# FAFO_BANK_SYNC=true      # Sync linked bank accounts before reconciliation
+
 # Optional — Safety
 # FAFO_DRY_RUN=true        # Log changes without applying them

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Your Actual Budget categories must be organized into four category groups:
 | `FAFO_RECON_TIME` | No | `02:00` | Time of day to run (HH:MM, 24hr) |
 | `TZ` | No | `UTC` | Timezone |
 | `FAFO_OTHER_CATEGORY` | No | *(first in group)* | Name of the catch-all category in the Other group |
+| `FAFO_BANK_SYNC` | No | `false` | Sync linked bank accounts before reconciliation |
 | `FAFO_DRY_RUN` | No | `false` | Log changes without applying them |
 | `FAFO_HEALTH_PORT` | No | `8080` | Port for the health check HTTP endpoint |
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ fafo_budget:
 
 ## Monitoring
 
-The container exposes an HTTP health check endpoint on port 8080 (configurable via `FAFO_HEALTH_PORT`). Any request returns `200 OK`.
+The container exposes two HTTP endpoints on port 8080 (configurable via `FAFO_HEALTH_PORT`):
 
-The Dockerfile includes a `HEALTHCHECK` instruction, so Docker will automatically report container health. For external monitoring (e.g. Uptime Kuma), point an HTTP monitor at `http://fafo_budget:8080`.
+| Endpoint | Description |
+|---|---|
+| `GET /` | Basic health check — always returns `200 OK` |
+| `GET /sync` | Bank sync status — returns `200` with JSON state on success, `500` on sync error. Possible states: `pending`, `success`, `error`, `disabled` |
+
+The Dockerfile includes a `HEALTHCHECK` instruction, so Docker will automatically report container health. For external monitoring (e.g. Uptime Kuma), use `/` for general uptime and `/sync` to alert on bank sync failures.
 
 ## Development
 

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -21,6 +21,12 @@ export async function sync(): Promise<void> {
   await api.sync();
 }
 
+export async function runBankSync(): Promise<void> {
+  logger.info('Running bank sync for all linked accounts');
+  await api.runBankSync();
+  logger.info('Bank sync complete');
+}
+
 export async function disconnect(): Promise<void> {
   try {
     await api.shutdown();

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export interface Config {
     otherCategory: string | null;
     dryRun: boolean;
     healthPort: number;
+    bankSync: boolean;
   };
 }
 
@@ -68,6 +69,7 @@ export function loadConfig(): Config {
       otherCategory: process.env['FAFO_OTHER_CATEGORY'] || null,
       dryRun: process.env['FAFO_DRY_RUN'] === 'true',
       healthPort: optionalInt('FAFO_HEALTH_PORT', 8080),
+      bankSync: process.env['FAFO_BANK_SYNC'] === 'true',
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { loadConfig } from './config';
 import { connect, disconnect, runBankSync } from './actual';
 import { reconcile } from './reconcile';
 import { logger } from './logger';
+import { getSyncState, setSyncSuccess, setSyncError, setSyncDisabled } from './syncStatus';
 
 async function runScheduledJob(): Promise<void> {
   const config = loadConfig();
@@ -11,7 +12,16 @@ async function runScheduledJob(): Promise<void> {
     await connect(config);
 
     if (config.fafo.bankSync) {
-      await runBankSync();
+      try {
+        await runBankSync();
+        setSyncSuccess();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setSyncError(message);
+        throw err;
+      }
+    } else {
+      setSyncDisabled();
     }
 
     await reconcile(config);
@@ -48,8 +58,15 @@ async function main(): Promise<void> {
 
   logger.info(`Scheduler active — next run at ${config.fafo.reconTime} daily`);
 
-  // Health check endpoint for monitoring (e.g. Uptime Kuma)
+  // HTTP endpoints for monitoring (e.g. Uptime Kuma)
   const server = http.createServer((_req, res) => {
+    if (_req.url === '/sync') {
+      const state = getSyncState();
+      const statusCode = state.status === 'error' ? 500 : 200;
+      res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(state));
+      return;
+    }
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('OK');
   });

--- a/src/syncStatus.ts
+++ b/src/syncStatus.ts
@@ -1,0 +1,23 @@
+type SyncState =
+  | { status: 'pending' }
+  | { status: 'disabled' }
+  | { status: 'success'; timestamp: string }
+  | { status: 'error'; timestamp: string; message: string };
+
+let state: SyncState = { status: 'pending' };
+
+export function getSyncState(): SyncState {
+  return state;
+}
+
+export function setSyncSuccess(): void {
+  state = { status: 'success', timestamp: new Date().toISOString() };
+}
+
+export function setSyncError(message: string): void {
+  state = { status: 'error', timestamp: new Date().toISOString(), message };
+}
+
+export function setSyncDisabled(): void {
+  state = { status: 'disabled' };
+}


### PR DESCRIPTION
## Summary

- Adds `FAFO_BANK_SYNC` option (default `false`) that syncs all linked bank accounts at the scheduled daily run time before reconciliation
- Bank sync runs via the Actual Budget API's `runBankSync()`, pulling latest transactions from all connected providers (SimpleFin, GoCardless, etc.)
- Reconciliation continues to run afterward only if within the configured window

Closes #3

## Test plan

- [ ] Set `FAFO_BANK_SYNC=true` and verify bank sync runs before reconciliation in logs
- [ ] Verify bank sync is skipped when `FAFO_BANK_SYNC` is not set or `false`
- [ ] Confirm reconciliation still works correctly after bank sync
- [ ] Verify errors during bank sync are caught and logged without crashing the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)