### PR TITLE
ci: lint PR titles for Conventional Commits compliance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,12 @@ TZ=America/New_York        # Timezone
 
 # Optional — Safety
 # FAFO_DRY_RUN=true        # Log changes without applying them
+
+# Optional — PCE inflation adjustment
+# When FRED_API_KEY is set, FAFO_MONTHLY_TARGET is automatically adjusted for
+# cumulative PCE inflation since BUDGET_START_DATE. Allowances are only
+# inflation-adjusted if BASE_ALLOWANCE_* vars are provided.
+# FRED_API_KEY=your-fred-api-key
+# BUDGET_START_DATE=2025-05-01        # Month the budget baseline was set (YYYY-MM-DD)
+# BASE_ALLOWANCE_ALICE=200            # Optional: base allowance per household member
+# BASE_ALLOWANCE_BOB=200

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,34 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types, kept in sync with release-please-config.json
+          types: |
+            feat
+            fix
+            perf
+            docs
+            chore
+            refactor
+            test
+            build
+            ci
+            style
+            revert

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ With default settings (`start=28`, `end=5`):
 - **Feb 6–27**: No reconciliation (outside window)
 - **Feb 28–Mar 5**: Same process for February → March
 
+## Inflation adjustment
+
+Without inflation adjustment, rising prices silently eat into the Other category's budget, creating negative carryover that's indistinguishable from actual overspending. This corrupts the FAFO signal.
+
+When `FRED_API_KEY` and `BUDGET_START_DATE` are set, the reconciler automatically adjusts `FAFO_MONTHLY_TARGET` (and optionally allowance budgets) for cumulative inflation since the budget start date using the [PCE Price Index](https://fred.stlouisfed.org/series/PCEPI) from the Federal Reserve (FRED).
+
+PCE is used instead of CPI because it accounts for substitution effects — when one good gets expensive, consumers shift spending to alternatives. CPI assumes a fixed basket, which tends to overstate inflation as experienced by households. This makes PCE a better fit for adjusting a real spending budget.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FRED_API_KEY` | No | — | Enables inflation adjustment ([request one here](https://fred.stlouisfed.org/docs/api/api_key.html)) |
+| `BUDGET_START_DATE` | When `FRED_API_KEY` set | — | Month the baseline was set (YYYY-MM-DD) |
+| `BASE_ALLOWANCE_*` | No | — | Base allowance per member (e.g. `BASE_ALLOWANCE_ALICE=200`) |
+
+If the FRED API is unavailable, the reconciler logs a warning and uses unadjusted base values.
+
 ## Docker Compose
 
 ```yaml

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,9 @@
+export interface InflationConfig {
+  fredApiKey: string;
+  budgetStartDate: string; // YYYY-MM-DD
+  baseAllowances: Record<string, number>; // lowercase category name -> dollars (may be empty)
+}
+
 export interface Config {
   actual: {
     serverUrl: string;
@@ -13,6 +19,7 @@ export interface Config {
     dryRun: boolean;
     healthPort: number;
     bankSync: boolean;
+    inflation: InflationConfig | null;
   };
 }
 
@@ -55,6 +62,30 @@ export function loadConfig(): Config {
     throw new Error(`FAFO_MONTHLY_TARGET must be a positive number, got ${targetStr}`);
   }
 
+  // Parse optional inflation config
+  let inflation: InflationConfig | null = null;
+  const fredApiKey = process.env['FRED_API_KEY'];
+  if (fredApiKey) {
+    const budgetStartDate = required('BUDGET_START_DATE');
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(budgetStartDate)) {
+      throw new Error(`BUDGET_START_DATE must be YYYY-MM-DD format, got ${budgetStartDate}`);
+    }
+
+    const baseAllowances: Record<string, number> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (key.startsWith('BASE_ALLOWANCE_') && value) {
+        const name = key.slice('BASE_ALLOWANCE_'.length).toLowerCase();
+        const amount = parseFloat(value);
+        if (isNaN(amount) || amount <= 0) {
+          throw new Error(`${key} must be a positive number, got ${value}`);
+        }
+        baseAllowances[name] = amount;
+      }
+    }
+
+    inflation = { fredApiKey, budgetStartDate, baseAllowances };
+  }
+
   return {
     actual: {
       serverUrl: required('ACTUAL_SERVER_URL'),
@@ -70,6 +101,7 @@ export function loadConfig(): Config {
       dryRun: process.env['FAFO_DRY_RUN'] === 'true',
       healthPort: optionalInt('FAFO_HEALTH_PORT', 8080),
       bankSync: process.env['FAFO_BANK_SYNC'] === 'true',
+      inflation,
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ async function main(): Promise<void> {
     dryRun: config.fafo.dryRun,
     monthlyTarget: config.fafo.monthlyTarget,
     bankSync: config.fafo.bankSync,
+    inflation: config.fafo.inflation
+      ? {
+          budgetStartDate: config.fafo.inflation.budgetStartDate,
+          baseAllowances: config.fafo.inflation.baseAllowances,
+        }
+      : false,
   });
 
   // Run once on startup

--- a/src/inflation.ts
+++ b/src/inflation.ts
@@ -1,0 +1,85 @@
+import { logger } from './logger';
+
+interface FREDObservation {
+  date: string;
+  value: string;
+}
+
+interface FREDResponse {
+  observations?: FREDObservation[];
+}
+
+export interface InflationAdjustment {
+  startPcepi: number;
+  latestPcepi: number;
+  cumulativeChange: number; // e.g. 0.03 for 3% inflation
+}
+
+async function fetchFredObservation(
+  fredApiKey: string,
+  params: Record<string, string>,
+): Promise<number | null> {
+  const url = new URL('https://api.stlouisfed.org/fred/series/observations');
+  url.searchParams.set('series_id', 'PCEPI');
+  url.searchParams.set('units', 'lin');
+  url.searchParams.set('file_type', 'json');
+  url.searchParams.set('api_key', fredApiKey);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error(`FRED API returned ${response.status}: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as FREDResponse;
+  if (!data.observations?.length) return null;
+
+  const value = parseFloat(data.observations[0].value);
+  return isNaN(value) ? null : value;
+}
+
+export async function getInflationAdjustment(
+  fredApiKey: string,
+  budgetStartDate: string,
+): Promise<InflationAdjustment | null> {
+  try {
+    // Get the PCEPI value at or just before the budget start date.
+    // PCEPI is released monthly (dated 1st of month). Using observation_end
+    // with sort_order=desc handles the case where the start date doesn't
+    // land exactly on a release date.
+    const startPcepi = await fetchFredObservation(fredApiKey, {
+      observation_end: budgetStartDate,
+      sort_order: 'desc',
+      limit: '1',
+    });
+
+    if (startPcepi === null) {
+      logger.warn('Could not retrieve start PCEPI value from FRED');
+      return null;
+    }
+
+    // Get the most recent PCEPI value from the start date onwards
+    const latestPcepi = await fetchFredObservation(fredApiKey, {
+      observation_start: budgetStartDate,
+      sort_order: 'desc',
+      limit: '1',
+    });
+
+    if (latestPcepi === null) {
+      logger.warn('Could not retrieve latest PCEPI value from FRED');
+      return null;
+    }
+
+    const cumulativeChange = latestPcepi / startPcepi - 1;
+
+    return { startPcepi, latestPcepi, cumulativeChange };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn('Failed to fetch PCE inflation data, skipping adjustment', {
+      error: message,
+    });
+    return null;
+  }
+}

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -1,5 +1,6 @@
 import { api } from './actual';
 import { Config } from './config';
+import { getInflationAdjustment } from './inflation';
 import { logger } from './logger';
 
 // The @actual-app/api types for getBudgetMonth.categoryGroups are Record<string, unknown>[].
@@ -157,7 +158,51 @@ export async function reconcile(config: Config): Promise<void> {
     }
   }
 
-  const targetMonthlyAmount = Math.round(config.fafo.monthlyTarget * 100); // Actual uses integer cents
+  // Compute inflation-adjusted values if configured
+  let effectiveTarget = config.fafo.monthlyTarget; // dollars
+  let effectiveAllowances: Record<string, number> | null = null; // lowercase name -> cents
+
+  if (config.fafo.inflation) {
+    const { fredApiKey, budgetStartDate, baseAllowances } = config.fafo.inflation;
+    const hasBaseAllowances = Object.keys(baseAllowances).length > 0;
+    const adjustment = await getInflationAdjustment(fredApiKey, budgetStartDate);
+
+    if (adjustment) {
+      const multiplier = 1 + adjustment.cumulativeChange;
+      effectiveTarget = config.fafo.monthlyTarget * multiplier;
+
+      logger.info('PCE inflation adjustment applied', {
+        startPcepi: adjustment.startPcepi,
+        latestPcepi: adjustment.latestPcepi,
+        cumulativeChangePct: `${(adjustment.cumulativeChange * 100).toFixed(2)}%`,
+        baseTarget: config.fafo.monthlyTarget,
+        effectiveTarget: Math.round(effectiveTarget * 100) / 100,
+      });
+
+      if (hasBaseAllowances) {
+        effectiveAllowances = {};
+        for (const [name, base] of Object.entries(baseAllowances)) {
+          const adjusted = Math.round(base * multiplier * 100); // cents
+          effectiveAllowances[name] = adjusted;
+          logger.info(`Allowance inflation adjustment: "${name}"`, {
+            base,
+            effective: adjusted / 100,
+          });
+        }
+      }
+    } else {
+      // API failure — use base values without adjustment
+      logger.warn('Using base values without inflation adjustment');
+      if (hasBaseAllowances) {
+        effectiveAllowances = {};
+        for (const [name, base] of Object.entries(baseAllowances)) {
+          effectiveAllowances[name] = Math.round(base * 100);
+        }
+      }
+    }
+  }
+
+  const targetMonthlyAmount = Math.round(effectiveTarget * 100); // Actual uses integer cents
 
   // Step 1: Copy Fixed budgets from source month to target month
   const sourceFixedGroup = findGroup(sourceGroups, 'Fixed')!;
@@ -179,7 +224,9 @@ export async function reconcile(config: Config): Promise<void> {
     }
   }
 
-  // Step 2: Copy Allowance budgets from source month to target month
+  // Step 2: Set Allowance budgets for target month.
+  // When inflation is configured, use inflation-adjusted base allowances.
+  // Otherwise, copy from the source month as before.
   const sourceAllowancesGroup = findGroup(sourceGroups, 'Allowances')!;
   const targetAllowancesGroup = findGroup(targetGroups, 'Allowances')!;
   let allowancesTotal = 0;
@@ -188,7 +235,12 @@ export async function reconcile(config: Config): Promise<void> {
     const targetCat = targetAllowancesGroup.categories.find((c) => c.id === sourceCat.id);
     if (!targetCat) continue;
 
-    const newBudget = sourceCat.budgeted;
+    let newBudget: number;
+    if (effectiveAllowances && sourceCat.name.toLowerCase() in effectiveAllowances) {
+      newBudget = effectiveAllowances[sourceCat.name.toLowerCase()];
+    } else {
+      newBudget = sourceCat.budgeted;
+    }
     allowancesTotal += newBudget;
 
     if (targetCat.budgeted !== newBudget) {
@@ -294,6 +346,7 @@ export async function reconcile(config: Config): Promise<void> {
   logger.info('Reconciliation complete', {
     targetMonth: window.targetMonth,
     target: targetMonthlyAmount / 100,
+    ...(config.fafo.inflation ? { baseTarget: config.fafo.monthlyTarget } : {}),
     fixed: fixedTotal / 100,
     flex: flexTotal / 100,
     allowances: allowancesTotal / 100,


### PR DESCRIPTION
## What

Adds a `Lint PR Title` workflow that validates every pull request title against the [Conventional Commits](https://www.conventionalcommits.org/) spec using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).

## Why

release-please recently failed with:

```
commit could not be parsed: ... add optional PCE inflation adjustment ... (#10)
error message: Error: unexpected token ' ' at 1:4, valid tokens [(, !, :]
```

Because PRs are squash-merged, the **PR title** becomes the commit message on `main`. A non-conventional title (`add ...` instead of `feat: add ...`) produces a commit that release-please can't parse, which hard-fails the release. This check blocks such titles at PR time so they never reach `main`.

The allowed types mirror the `changelog-sections` in `release-please-config.json` (`feat`, `fix`, `perf`, `docs`, `chore`) plus the other standard Conventional Commit types.

## Recommended companion setting (manual)

In **Settings → General → Pull Requests**, set the squash-merge **"Default commit message"** to **"Pull request title"** so the linted title is exactly what lands on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V1zqS9Nzd9gbfXnh7PRveb)_