### PR TITLE
fix: stop SimpleFIN crash loop from failed bank sync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,9 +106,6 @@ async function main(): Promise<void> {
       : false,
   });
 
-  // Run once on startup
-  await runScheduledJob();
-
   // Schedule daily
   cron.schedule(cronExpr, () => {
     runScheduledJob();
@@ -154,6 +151,21 @@ async function main(): Promise<void> {
     logger.info(`Health check listening on port ${config.fafo.healthPort}`);
   });
 }
+
+// The @actual-app/api client can throw asynchronously from its internal sync
+// (e.g. a failed bank sync) after the awaited call has already rejected. Those
+// escape the try/catch in runScheduledJob, so without these handlers Node would
+// crash the whole process. Log and keep the daemon alive instead.
+process.on('unhandledRejection', (reason) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  logger.error('Unhandled promise rejection (ignored, daemon continues)', { error: message });
+});
+
+process.on('uncaughtException', (err) => {
+  logger.error('Uncaught exception (ignored, daemon continues)', {
+    error: err instanceof Error ? err.message : String(err),
+  });
+});
 
 // Graceful shutdown
 process.on('SIGTERM', async () => {


### PR DESCRIPTION
## Problem

A failed bank sync caused `@actual-app/api` to throw asynchronously from its internal sync, *after* `await runBankSync()` had already rejected. The stray rejection escaped the `try/catch` in `runScheduledJob`, and with no global handler it crashed the process. With `restart: unless-stopped`, the container restarted and immediately re-ran the startup sync → another failure → crash loop.

## Fix

- Add `unhandledRejection` / `uncaughtException` handlers that log and keep the daemon alive.
- Remove the run-on-startup sync, so a restart can't trigger an immediate sync. Syncs now run only on the daily cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)