### PR TITLE
fix: keep @actual-app/api in lockstep with actual-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,26 @@
+# @actual-app/api must match the running actual-server version exactly or
+# downloadBudget fails with out-of-sync-migrations. Pass the server version as
+# a build arg (the build pipeline derives it from the compose tag) to pin the
+# client in lockstep. Empty arg falls back to the package.json pin. An arg that
+# isn't on npm fails the build loudly rather than shipping a mismatched client.
+ARG ACTUAL_API_VERSION=""
+
 FROM node:22-slim AS builder
 WORKDIR /app
+ARG ACTUAL_API_VERSION
 COPY package.json package-lock.json ./
 RUN npm ci
+RUN if [ -n "$ACTUAL_API_VERSION" ]; then npm install --no-save @actual-app/api@"$ACTUAL_API_VERSION"; fi
 COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
 FROM node:22-slim
 WORKDIR /app
+ARG ACTUAL_API_VERSION
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
+RUN if [ -n "$ACTUAL_API_VERSION" ]; then npm install --no-save @actual-app/api@"$ACTUAL_API_VERSION"; fi
 COPY --from=builder /app/dist/ ./dist/
 USER node
 EXPOSE 8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "26.5.2",
+        "@actual-app/api": "26.6.0",
         "imapflow": "^1.0.171",
         "mailparser": "^3.7.1",
         "node-cron": "^3.0.3"
@@ -23,25 +23,25 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.5.2.tgz",
-      "integrity": "sha512-BlJvnzTyRf2CRWgZA8I3/lVnBst9+jOzpQ80Fho9wVI40dY90b2ezlfxXSQ9wgmqr8mXygKdwZkUXVQd8cGJFg==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.6.0.tgz",
+      "integrity": "sha512-nDmBGyhEmJpb2SRXxGN+LrNMAJMTMOkbOtk3GG7QKWc2EiqMEbsTiYtxcHyU1X+HV7jxnez6mQW4c7srPf61fA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.5.2",
-        "@actual-app/crdt": "2.1.0",
+        "@actual-app/core": "26.6.0",
+        "@actual-app/crdt": "3.0.0",
         "better-sqlite3": "^12.8.0",
         "compare-versions": "^6.1.1",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.5.2.tgz",
-      "integrity": "sha512-KcosLcObhCX28JA4IMAeOOKstsC9Ffd9PZVBvn/sAZrKwDoHziNwOO8W8FVWaetxyy2pcXTsEWDfZHm6drlJ8A==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.6.0.tgz",
+      "integrity": "sha512-qrlsds+DpYxrjfQa5BEPOw9eOxQFt6z4zDLo2tt+veBHIwVnD1ewjsycIOxs57Nl+o872SXvsf1XNamoz9Lhdg==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -53,7 +53,6 @@
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "date-fns": "^4.1.0",
-        "google-protobuf": "^3.21.4",
         "handlebars": "^4.7.9",
         "hyperformula": "^3.2.0",
         "lodash": "^4.18.1",
@@ -63,33 +62,26 @@
         "promise-retry": "^2.0.1",
         "typescript-strict-plugin": "^2.4.4",
         "ua-parser-js": "^2.0.9",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "xml2js": "^0.6.2"
       }
     },
     "node_modules/@actual-app/crdt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-2.1.0.tgz",
-      "integrity": "sha512-Qb8hMq10Wi2kYIDj0fG4uy00f9Mloghd+xQrHQiPQfgx022VPJ/No+z/bmfj4MuFH8FrPiLysSzRsj2PNQIedw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-3.0.0.tgz",
+      "integrity": "sha512-qTdqAa5rPGBLDld932ox4ADRLpX+SDXIyuJpdP0GIimH6ekYX375bwLrWznev2B8aIZVU+R83I6+ltV2lQOpvg==",
       "license": "MIT",
       "dependencies": {
-        "google-protobuf": "^3.12.0-rc.1",
+        "@bufbuild/protobuf": "^2.11.0",
         "murmurhash": "^2.0.1",
-        "uuid": "^9.0.0"
+        "uuid": "^14.0.0"
       }
     },
-    "node_modules/@actual-app/crdt/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
@@ -624,9 +616,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -692,9 +684,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -875,15 +867,15 @@
       "license": "MIT"
     },
     "node_modules/csv-stringify": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
-      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.0.tgz",
+      "integrity": "sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
-      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1200,12 +1192,6 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
-    },
-    "node_modules/google-protobuf": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
-      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -2119,9 +2105,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2319,9 +2305,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -2525,9 +2511,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -2622,9 +2608,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@actual-app/api": "26.5.2",
+    "@actual-app/api": "26.6.0",
     "imapflow": "^1.0.171",
     "mailparser": "^3.7.1",
     "node-cron": "^3.0.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { loadConfig, Config } from './config';
 import { connect, disconnect, runBankSync, sync, importPaypalTransactions } from './actual';
 import { processPaypalInbox } from './imap';
 import { reconcile } from './reconcile';
-import { logger } from './logger';
+import { logger, errorMessage } from './logger';
 import {
   getSyncState,
   setSyncSuccess,
@@ -37,7 +37,7 @@ async function runScheduledJob(): Promise<void> {
           await runBankSync();
           setSyncSuccess();
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = errorMessage(err);
           setSyncError(message);
           throw err;
         }
@@ -47,7 +47,7 @@ async function runScheduledJob(): Promise<void> {
 
       await reconcile(config);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = errorMessage(err);
       logger.error('Scheduled job failed', { error: message });
     } finally {
       await disconnect();
@@ -79,7 +79,7 @@ async function runPaypalPoll(config: Config): Promise<void> {
     }
     setPaypalSuccess(result.imported);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     logger.error('PayPal poll failed', { error: message });
     setPaypalError(message);
   }
@@ -157,13 +157,13 @@ async function main(): Promise<void> {
 // escape the try/catch in runScheduledJob, so without these handlers Node would
 // crash the whole process. Log and keep the daemon alive instead.
 process.on('unhandledRejection', (reason) => {
-  const message = reason instanceof Error ? reason.message : String(reason);
+  const message = errorMessage(reason);
   logger.error('Unhandled promise rejection (ignored, daemon continues)', { error: message });
 });
 
 process.on('uncaughtException', (err) => {
   logger.error('Uncaught exception (ignored, daemon continues)', {
-    error: err instanceof Error ? err.message : String(err),
+    error: errorMessage(err),
   });
 });
 
@@ -181,6 +181,6 @@ process.on('SIGINT', async () => {
 });
 
 main().catch((err) => {
-  logger.error('Fatal error', { error: err instanceof Error ? err.message : String(err) });
+  logger.error('Fatal error', { error: errorMessage(err) });
   process.exit(1);
 });

--- a/src/inflation.ts
+++ b/src/inflation.ts
@@ -1,4 +1,4 @@
-import { logger } from './logger';
+import { logger, errorMessage } from './logger';
 
 interface FREDObservation {
   date: string;
@@ -76,7 +76,7 @@ export async function getInflationAdjustment(
 
     return { startPcepi, latestPcepi, cumulativeChange };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     logger.warn('Failed to fetch PCE inflation data, skipping adjustment', {
       error: message,
     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,6 +15,26 @@ function log(level: Level, message: string, data?: Record<string, unknown>): voi
   }
 }
 
+/**
+ * Extract a readable message from an unknown thrown value. Some dependencies
+ * (notably @actual-app/api) reject with plain objects like
+ * `{ type: 'APIError', message: '...' }`; `String(err)` turns those into the
+ * useless `[object Object]`, so prefer a `.message` field and fall back to JSON.
+ */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === 'object') {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string' && m) return m;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
 export const logger = {
   info: (msg: string, data?: Record<string, unknown>) => log('info', msg, data),
   warn: (msg: string, data?: Record<string, unknown>) => log('warn', msg, data),


### PR DESCRIPTION
Fixes the recurring version-mismatch breakage where `@actual-app/api` drifts from the running `actual-server`, causing `downloadBudget` to fail with `out-of-sync-migrations` and taking down PayPal import + bank sync. (All Actual packages are released together at the same version, so the client must match the server exactly.)

**Changes**
- Bump `@actual-app/api` 26.5.2 → 26.6.0 (matches current server) as the committed fallback pin.
- `Dockerfile`: accept `ACTUAL_API_VERSION` build arg and pin the client to it. The deploy pipeline derives this from the `actual-server` compose tag, so a server bump propagates to the client on the next rebuild. A version not on npm fails the build loudly rather than shipping a mismatch.
- Serialize thrown non-`Error` objects via a shared `errorMessage()` helper — `@actual-app/api` rejects with `{type,message}` objects that `String()`-ified to `[object Object]`, masking the real cause.

**Verified locally**
- `tsc` clean, 7/7 tests pass.
- Build with `--build-arg ACTUAL_API_VERSION=26.6.0` installs 26.6.0; a bogus version fails with `ETARGET`.
- Container recreated: budget downloads cleanly, 3 queued PayPal emails imported, `/paypal` + `/sync` return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)